### PR TITLE
fix: name is optional field for workspaces

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -250,8 +250,7 @@ export async function getWorkspaceModules(
       join(root, workspace),
     );
     if (!workspaceConfig.name) {
-      console.log(`${path} doesn't have name field.`);
-      Deno.exit(1);
+      continue;
     }
     result.push({ ...workspaceConfig, [pathProp]: path });
   }


### PR DESCRIPTION
`deno publish` command simply ignores the workspaces without name fields. I think this tool should be act similarly in case of consistent behavior.