### PR TITLE
feat: bumping modules with wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ in README.
 - perf
 - deprecation
 
+## Wildcard scope
+
+You can use `*` for the scope. That commit affects all the packages in the workspace. For example:
+
+```
+refactor(*): clean up
+```
+
+The above commit causes `patch` upgrade to the all packages.
+
 # License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ in README.
 
 ## Wildcard scope
 
-You can use `*` for the scope. That commit affects all the packages in the workspace. For example:
+You can use `*` for the scope. That commit affects all the packages in the
+workspace. For example:
 
 ```
 refactor(*): clean up

--- a/mod.ts
+++ b/mod.ts
@@ -38,6 +38,7 @@ import {
   summarizeVersionBumpsByModule,
   type VersionBump,
   type VersionUpdateResult,
+  type WorkspaceModule,
 } from "./util.ts";
 
 // A random separator that is unlikely to be in a commit message.
@@ -49,7 +50,10 @@ export type BumpWorkspaceOptions = {
   start?: string;
   /** The base branch name to compare commits. The default is the current branch. */
   base?: string;
-  parseCommitMessage?: (commit: Commit) => VersionBump[] | Diagnostic;
+  parseCommitMessage?: (
+    commit: Commit,
+    workspaceModules: WorkspaceModule[],
+  ) => VersionBump[] | Diagnostic;
   /** The root directory of the workspace. */
   root?: string;
   /** The git user name which is used for making a commit */
@@ -147,7 +151,7 @@ export async function bumpWorkspaces(
       // Skip if the commit subject is release
       continue;
     }
-    const parsed = parseCommitMessage(commit);
+    const parsed = parseCommitMessage(commit, modules);
     if (Array.isArray(parsed)) {
       for (const versionBump of parsed) {
         const diagnostic = checkModuleName(versionBump, modules);

--- a/util.ts
+++ b/util.ts
@@ -105,7 +105,7 @@ const TAG_TO_VERSION: Record<string, "major" | "minor" | "patch"> = {
 
 const TAG_PRIORITY = Object.keys(TAG_TO_VERSION);
 
-export const DEFAULT_RANGE_REQUIED = [
+export const DEFAULT_RANGE_REQUIRED = [
   "BREAKING",
   "feat",
   "fix",
@@ -115,6 +115,7 @@ export const DEFAULT_RANGE_REQUIED = [
 
 export function defaultParseCommitMessage(
   commit: Commit,
+  workspaceModules: WorkspaceModule[],
 ): VersionBump[] | Diagnostic {
   const match = RE_DEFAULT_PATTERN.exec(commit.subject);
   if (match === null) {
@@ -125,9 +126,13 @@ export function defaultParseCommitMessage(
     };
   }
   const [, tag, module, _message] = match;
-  const modules = module ? module.split(/\s*,\s*/) : [];
+  const modules = module === "*"
+    ? workspaceModules.map((x) => x.name)
+    : module
+    ? module.split(/\s*,\s*/)
+    : [];
   if (modules.length === 0) {
-    if (DEFAULT_RANGE_REQUIED.includes(tag)) {
+    if (DEFAULT_RANGE_REQUIRED.includes(tag)) {
       return {
         type: "missing_range",
         commit,
@@ -341,7 +346,7 @@ export async function applyVersionBump(
   if (oldModule.version !== module.version) {
     // The version is manually updated
     console.info(
-      `Manaul version update detected for ${module.name}: ${oldModule.version} -> ${module.version}`,
+      `Manual version update detected for ${module.name}: ${oldModule.version} -> ${module.version}`,
     );
 
     const diff = calcVersionDiff(module.version, oldModule.version);

--- a/util_test.ts
+++ b/util_test.ts
@@ -79,6 +79,29 @@ Deno.test("defaultParseCommitMessage()", () => {
     },
   ]);
 
+  assertEquals(parse("fix(*): a bug", modules), [
+    {
+      module: "foo",
+      tag: "fix",
+      version: "patch",
+      commit: {
+        subject: "fix(*): a bug",
+        body: "",
+        hash,
+      },
+    },
+    {
+      module: "bar",
+      tag: "fix",
+      version: "patch",
+      commit: {
+        subject: "fix(*): a bug",
+        body: "",
+        hash,
+      },
+    },
+  ]);
+
   assertEquals(parse("BREAKING(foo): some breaking change", modules), [
     {
       module: "foo",


### PR DESCRIPTION
This improvement enables to detect wildcard patterns that points out developments which affects all available modules/components.

Basically, instead of "feat(archive,assert,async,bytes,cli,collections...): upgraded dependency @std/assert to version 1.0.0",

we will be able to use
"feat(*): upgraded dependency @std/assert to version 1.0.0"