### PR TITLE
feat: support unstable scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,16 @@ The above commit causes `patch` upgrade to the all packages.
 
 ## Unstable updates
 
-You can mark the change only affects the unstable part of the package by using `scope/unstable` or `unstable/scope`.
+You can mark the change only affects the unstable part of the package by using
+`scope/unstable` or `unstable/scope`.
 
 ```
 feat(crypto/unstable): a new unstable feature
 BREAKING(crypto/unstable): breaking change to unstable feature
 ```
 
-If this notation is used, the effect of the commit becomes `patch` no matter what commit type is used.
+If this notation is used, the effect of the commit becomes `patch` no matter
+what commit type is used.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ refactor(*): clean up
 
 The above commit causes `patch` upgrade to the all packages.
 
+## Unstable updates
+
+You can mark the change only affects the unstable part of the package by using `scope/unstable` or `unstable/scope`.
+
+```
+feat(crypto/unstable): a new unstable feature
+BREAKING(crypto/unstable): breaking change to unstable feature
+```
+
+If this notation is used, the effect of the commit becomes `patch` no matter what commit type is used.
+
 # License
 
 MIT

--- a/util_test.ts
+++ b/util_test.ts
@@ -205,6 +205,35 @@ Deno.test("defaultParseCommitMessage()", () => {
       },
     },
   ]);
+
+  assertEquals(parse("feat(foo/unstable): a new unstable feature", modules), [
+    {
+      module: "foo",
+      tag: "feat",
+      version: "patch",
+      commit: {
+        subject: "feat(foo/unstable): a new unstable feature",
+        body: "",
+        hash,
+      },
+    },
+  ]);
+
+  assertEquals(
+    parse("BREAKING(unstable/foo): break some unstable feature", modules),
+    [
+      {
+        module: "foo",
+        tag: "BREAKING",
+        version: "patch",
+        commit: {
+          subject: "BREAKING(unstable/foo): break some unstable feature",
+          body: "",
+          hash,
+        },
+      },
+    ],
+  );
 });
 
 Deno.test("checkModuleName()", () => {


### PR DESCRIPTION
This PR adds the feature for handling `foo/unstable` scope. If that scope is used, the effect of the commit becomes `patch` no matter what the commit type is.


```
BREAKING(foo/unstable): blah blah # => patch upgrade to `foo`
feat(foo/unstable): blah blah # => patch upgrade to `foo`
```

closes https://github.com/denoland/std/issues/5578