### PR TITLE
feat: add `--import-map` option

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -16,12 +16,22 @@ import { bumpWorkspaces } from "./mod.ts";
  * deno run -A jsr:@deno/bump-workspaces --dry-run
  * ```
  *
+ * You can specify import map path by `--import-map` option (Default is deno.json(c) at the root):
+ *
+ * ```sh
+ * deno run -A jsr:@deno/bump-workspaces --import-map ./import_map.json
+ * ```
+ *
  * @module
  */
 
 if (import.meta.main) {
   const args = parseArgs(Deno.args, {
+    string: ["import-map"],
     boolean: ["dry-run"],
   });
-  await bumpWorkspaces({ dryRun: args["dry-run"] });
+  await bumpWorkspaces({
+    dryRun: args["dry-run"],
+    importMap: args["import-map"],
+  });
 }

--- a/cli.ts
+++ b/cli.ts
@@ -7,19 +7,19 @@ import { bumpWorkspaces } from "./mod.ts";
  * The CLI entrypoint of the package. You can directly perform the version bump behavior from CLI:
  *
  * ```sh
- * deno run -A jsr:@deno/bump-workspaces
+ * deno run -A jsr:@deno/bump-workspaces/cli
  * ```
  *
  * The endpoint supports --dry-run option:
  *
  * ```sh
- * deno run -A jsr:@deno/bump-workspaces --dry-run
+ * deno run -A jsr:@deno/bump-workspaces/cli --dry-run
  * ```
  *
  * You can specify import map path by `--import-map` option (Default is deno.json(c) at the root):
  *
  * ```sh
- * deno run -A jsr:@deno/bump-workspaces --import-map ./import_map.json
+ * deno run -A jsr:@deno/bump-workspaces/cli --import-map ./import_map.json
  * ```
  *
  * @module
@@ -31,7 +31,7 @@ if (import.meta.main) {
     boolean: ["dry-run"],
   });
   await bumpWorkspaces({
-    dryRun: args["dry-run"],
+    dryRun: "git",
     importMap: args["import-map"],
   });
 }

--- a/mod.ts
+++ b/mod.ts
@@ -177,7 +177,13 @@ export async function bumpWorkspaces(
   }
 
   console.log(`Updating the versions:`);
-  const importMapPath = importMap ? importMap : configPath;
+  let importMapPath: string;
+  if (importMap) {
+    console.log(`Using the import map: ${cyan(importMap)}`);
+    importMapPath = importMap;
+  } else {
+    importMapPath = configPath;
+  }
   const updates: Record<string, VersionUpdateResult> = {};
   let importMapJson = await Deno.readTextFile(importMapPath);
   for (const summary of summaries) {

--- a/mod.ts
+++ b/mod.ts
@@ -68,6 +68,8 @@ export type BumpWorkspaceOptions = {
    * Doesn't perform file edits and network operations when true.
    * Perform fs ops, but doesn't perform git operations when "network" */
   dryRun?: boolean | "git";
+  /** The import map path. Default is deno.json(c) at the root. */
+  importMap?: string;
   /** The path to release note markdown file. The dfault is `Releases.md` */
   releaseNotePath?: string;
 };
@@ -96,6 +98,7 @@ export async function bumpWorkspaces(
     githubToken,
     githubRepo,
     dryRun = false,
+    importMap,
     releaseNotePath = "Releases.md",
     root = ".",
   }: BumpWorkspaceOptions = {},
@@ -174,19 +177,20 @@ export async function bumpWorkspaces(
   }
 
   console.log(`Updating the versions:`);
+  const importMapPath = importMap ? importMap : configPath;
   const updates: Record<string, VersionUpdateResult> = {};
-  let denoJson = await Deno.readTextFile(configPath);
+  let importMapJson = await Deno.readTextFile(importMapPath);
   for (const summary of summaries) {
     const module = getModule(summary.module, modules)!;
     const oldModule = getModule(summary.module, oldModules);
-    const [denoJson_, versionUpdate] = await applyVersionBump(
+    const [importMapJson_, versionUpdate] = await applyVersionBump(
       summary,
       module,
       oldModule,
-      denoJson,
+      importMapJson,
       dryRun === true,
     );
-    denoJson = denoJson_;
+    importMapJson = importMapJson_;
     updates[module.name] = versionUpdate;
   }
   console.table(updates, ["diff", "from", "to", "path"]);
@@ -208,7 +212,7 @@ export async function bumpWorkspaces(
     console.log(cyan("Skip making a pull request."));
   } else {
     // Updates deno.json
-    await Deno.writeTextFile(configPath, denoJson);
+    await Deno.writeTextFile(importMapPath, importMapJson);
 
     // Prepend release notes
     await ensureFile(releaseNotePath);


### PR DESCRIPTION
This PR adds `--import-map` option. You can run the command with custom import map path.

```
deno run -A jsr:@deno/bump-workspaces/cli --import-map ./import_map.json
```